### PR TITLE
Custom xacro path option

### DIFF
--- a/summit_xl_gazebo/launch/summit_xl_gazebo.launch
+++ b/summit_xl_gazebo/launch/summit_xl_gazebo.launch
@@ -9,8 +9,6 @@
     <arg name="launch_robot_a" default="true"/>
     <arg name="launch_robot_b" default="false"/>
     <arg name="launch_robot_c" default="false"/>
-    <arg name="default_xacro_package" default="summit_xl_description"/>
-    <arg name="default_xacro" default="summit_xl_std.urdf.xacro"/>
     <arg name="gazebo_world" default="$(find summit_xl_gazebo)/worlds/summit_xl_office.world"/>
 	<arg name="gazebo_gui" default="true"/>
     <arg name="map_file" default="willow_garage/willow_garage.yaml"/>
@@ -34,8 +32,9 @@
 	<arg name="move_base_robot_a" default="false"/>
 	<arg name="amcl_and_mapserver_a" default="false"/>
 	<arg name="map_file_a" default="$(arg map_file)"/>
-	<arg name="xacro_robot_package_a" default="$(arg default_xacro_package)"/>
-	<arg name="xacro_robot_a" default="$(arg default_xacro)"/>
+	<arg name="xacro_robot_a" default="summit_xl_std.urdf.xacro"/>
+	<arg name="use_custom_xacro_path_robot_a" default="false"/>
+	<arg name="custom_xacro_path_robot_a" default="/home/robot/"/>
 	<arg name="launch_pad_a" default="false"/>
 	<arg name="gps_latitude_robot_a" default="39.5080331"/>
 	<arg name="gps_longitude_robot_a" default="-0.4619816"/>
@@ -57,8 +56,9 @@
 	<arg name="move_base_robot_b" default="false"/>
 	<arg name="amcl_and_mapserver_b" default="false"/>
 	<arg name="map_file_b" default="$(arg map_file)"/>
-	<arg name="xacro_robot_package_b" default="$(arg default_xacro_package)"/>
-	<arg name="xacro_robot_b" default="$(arg default_xacro)"/>
+	<arg name="xacro_robot_b" default="summit_xl_std.urdf.xacro"/>
+	<arg name="use_custom_xacro_path_robot_b" default="false"/>
+	<arg name="custom_xacro_path_robot_b" default="/home/robot/"/>
 	<arg name="launch_pad_b" default="false"/>
 	<arg name="gps_latitude_robot_b" default="39.5080331"/>
 	<arg name="gps_longitude_robot_b" default="-0.4619816"/>
@@ -80,8 +80,9 @@
 	<arg name="move_base_robot_c" default="false"/>
 	<arg name="amcl_and_mapserver_c" default="false"/>
 	<arg name="map_file_c" default="$(arg map_file)"/>
-	<arg name="xacro_robot_package_c" default="$(arg default_xacro_package)"/>
-	<arg name="xacro_robot_c" default="$(arg default_xacro)"/>
+	<arg name="xacro_robot_c" default="summit_xl_std.urdf.xacro"/>
+	<arg name="use_custom_xacro_path_robot_c" default="false"/>
+	<arg name="custom_xacro_path_robot_c" default="/home/robot/"/>
 	<arg name="launch_pad_c" default="false"/>
 	<arg name="gps_latitude_robot_c" default="39.5080331"/>
 	<arg name="gps_longitude_robot_c" default="-0.4619816"/>
@@ -98,8 +99,9 @@
 		<arg name="x_init_pose" value="$(arg x_init_pose_robot_a)"/>
 		<arg name="y_init_pose" value="$(arg y_init_pose_robot_a)"/>
 		<arg name="z_init_pose" value="$(arg z_init_pose_robot_a)"/>
-		<arg name="xacro_robot_package" value="$(arg xacro_robot_package_a)"/>
 		<arg name="xacro_robot" value="$(arg xacro_robot_a)"/>
+		<arg name="use_custom_xacro_path_robot" value="$(arg use_custom_xacro_path_robot_a)"/>
+		<arg name="custom_xacro_path_robot" value="$(arg custom_xacro_path_robot_a)"/>
         <arg name="launch_robot_ekf_localization" value="$(arg ekf_localization_robot_a)"/>
         <arg name="robot_ekf_localization_mode" value="$(arg ekf_localization_mode_a)"/>
 		<arg name="launch_amcl_and_mapserver" value="$(arg amcl_and_mapserver_a)"/>
@@ -128,8 +130,9 @@
 		<arg name="x_init_pose" value="$(arg x_init_pose_robot_b)"/>
 		<arg name="y_init_pose" value="$(arg y_init_pose_robot_b)"/>
 		<arg name="z_init_pose" value="$(arg z_init_pose_robot_b)"/>
-		<arg name="xacro_robot_package" value="$(arg xacro_robot_package_b)"/>
 		<arg name="xacro_robot" value="$(arg xacro_robot_b)"/>
+		<arg name="use_custom_xacro_path_robot" value="$(arg use_custom_xacro_path_robot_b)"/>
+		<arg name="custom_xacro_path_robot" value="$(arg custom_xacro_path_robot_b)"/>
         <arg name="launch_robot_ekf_localization" value="$(arg ekf_localization_robot_b)"/>
         <arg name="robot_ekf_localization_mode" value="$(arg ekf_localization_mode_b)"/>
 		<arg name="launch_amcl_and_mapserver" value="$(arg amcl_and_mapserver_b)"/>
@@ -159,8 +162,9 @@
 		<arg name="x_init_pose" value="$(arg x_init_pose_robot_c)"/>
 		<arg name="y_init_pose" value="$(arg y_init_pose_robot_c)"/>
 		<arg name="z_init_pose" value="$(arg z_init_pose_robot_c)"/>
-		<arg name="xacro_robot_package" value="$(arg xacro_robot_package_c)"/>
 		<arg name="xacro_robot" value="$(arg xacro_robot_c)"/>
+		<arg name="use_custom_xacro_path_robot" value="$(arg use_custom_xacro_path_robot_c)"/>
+		<arg name="custom_xacro_path_robot" value="$(arg custom_xacro_path_robot_c)"/>
         <arg name="launch_robot_ekf_localization" value="$(arg ekf_localization_robot_c)"/>
         <arg name="robot_ekf_localization_mode" value="$(arg ekf_localization_mode_c)"/>
 		<arg name="launch_amcl_and_mapserver" value="$(arg amcl_and_mapserver_c)"/>

--- a/summit_xl_gazebo/launch/summit_xl_one_robot.launch
+++ b/summit_xl_gazebo/launch/summit_xl_one_robot.launch
@@ -7,9 +7,10 @@
     <arg name="x_init_pose" default="0"/>
     <arg name="y_init_pose" default="0"/>
     <arg name="z_init_pose" default="0"/>
-    <arg name="xacro_robot_package" default="summit_xl_description"/>
     <arg name="xacro_robot" default="summit_xl_std.urdf.xacro"/>
-    <arg name="xacro_robot_path" default="$(eval find(xacro_robot_package) + '/robots/' + xacro_robot)"/>
+    <arg name="xacro_robot_path" default="$(find summit_xl_description)/robots/"/>
+    <arg name="use_custom_xacro_path_robot" default="false"/>
+    <arg name="custom_xacro_path_robot" default="/home/robot/"/>
     <arg name="launch_amcl_and_mapserver" default="false"/>
     <arg name="launch_gmapping" default="false"/>
     <arg name="launch_move_base" default="false"/>
@@ -52,15 +53,30 @@
     <group ns="$(arg id_robot)">
 
         <!-- Load the URDF into the ROS Parameter Server -->
-        <param name="robot_description" command="$(find xacro)/xacro '$(arg xacro_robot_path)'
-                prefix:=$(arg prefix)
-                ros_planar_move_plugin:=$(arg ros_planar_move_plugin)
-                ros_planar_move_plugin_force_based:=$(arg ros_planar_move_plugin_force_based)
-                omni_wheels:=$(arg omni_drive)
-                gpu:=$(arg use_gpu_for_simulation)
-                gps_latitude:='$(arg gps_latitude)'
-                gps_longitude:='$(arg gps_longitude)'
-                --inorder"/>
+        <group unless="$(arg use_custom_xacro_path_robot)" >
+            <param name="robot_description" command="$(find xacro)/xacro '$(arg xacro_robot_path)$(arg xacro_robot)'
+                    prefix:=$(arg prefix)
+                    ros_planar_move_plugin:=$(arg ros_planar_move_plugin)
+                    ros_planar_move_plugin_force_based:=$(arg ros_planar_move_plugin_force_based)
+                    omni_wheels:=$(arg omni_drive)
+                    gpu:=$(arg use_gpu_for_simulation)
+                    gps_latitude:='$(arg gps_latitude)'
+                    gps_longitude:='$(arg gps_longitude)'
+                    --inorder"/>
+        </group>
+
+        <group if="$(arg use_custom_xacro_path_robot)" >
+            <param name="robot_description" command="$(find xacro)/xacro '$(arg custom_xacro_path_robot)$(arg xacro_robot)'
+                    prefix:=$(arg prefix)
+                    ros_planar_move_plugin:=$(arg ros_planar_move_plugin)
+                    ros_planar_move_plugin_force_based:=$(arg ros_planar_move_plugin_force_based)
+                    omni_wheels:=$(arg omni_drive)
+                    gpu:=$(arg use_gpu_for_simulation)
+                    gps_latitude:='$(arg gps_latitude)'
+                    gps_longitude:='$(arg gps_longitude)'
+                    --inorder"/>
+        </group>
+
 
         <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="false" output="screen">
             <remap from="/joint_states" to="joint_states" />

--- a/summit_xl_sim_bringup/launch/summit_xl_complete.launch
+++ b/summit_xl_sim_bringup/launch/summit_xl_complete.launch
@@ -8,7 +8,9 @@
 	<arg name="gazebo_world" default="$(find summit_xl_gazebo)/worlds/summit_xl_office.world"/>
 	<arg name="gazebo_gui" default="true"/>
 	<arg name="omni_drive" default="false"/>
-	<arg name="default_xacro" default="summit_xl_std.urdf.xacro"/>
+	<arg name="default_xacro" default="$(optenv ROBOT_XACRO summit_xl_std.urdf.xacro)"/>
+	<arg name="use_custom_xacro_path" default="$(optenv ROBOT_USE_CUSTOM_XACRO_PATH false)"/>
+	<arg name="custom_xacro_path" default="$(optenv ROBOT_CUSTOM_XACRO_PATH /home/robot/)"/>
 	<arg if="$(arg omni_drive)" name="ros_planar_move_plugin" value="true"/>
 	<arg unless="$(arg omni_drive)" name="ros_planar_move_plugin" default="true"/>
 	<arg name="ros_planar_move_plugin_force_based" default="false"/>
@@ -21,6 +23,8 @@
 	<arg name="id_robot_a" default="robot"/>
 	<arg name="launch_robot_a" default="true"/>
 	<arg name="xacro_robot_a" default="$(arg default_xacro)"/>
+	<arg name="use_custom_xacro_path_robot_a" default="$(arg use_custom_xacro_path)"/>
+	<arg name="custom_xacro_path_robot_a" default="$(arg custom_xacro_path)"/>
 	<arg name="map_file_a" default="willow_garage/willow_garage.yaml"/>
 	<arg name="gmapping_robot_a" default="false"/>
 	<arg name="move_base_robot_a" default="true"/>
@@ -40,6 +44,8 @@
 	<arg name="id_robot_b" default="robot_b"/>
 	<arg name="launch_robot_b" default="false"/>
 	<arg name="xacro_robot_b" default="$(arg default_xacro)"/>
+	<arg name="use_custom_xacro_path_robot_b" default="$(arg use_custom_xacro_path)"/>
+	<arg name="custom_xacro_path_robot_b" default="$(arg custom_xacro_path)"/>
 	<arg name="map_file_b" default="willow_garage/willow_garage.yaml"/>
 	<arg name="gmapping_robot_b" default="false"/>
 	<arg name="move_base_robot_b" default="false"/>
@@ -59,6 +65,8 @@
 	<arg name="id_robot_c" default="robot_c"/>
 	<arg name="launch_robot_c" default="false"/>
 	<arg name="xacro_robot_c" default="$(arg default_xacro)"/>
+	<arg name="use_custom_xacro_path_robot_c" default="$(arg use_custom_xacro_path)"/>
+	<arg name="custom_xacro_path_robot_c" default="$(arg custom_xacro_path)"/>
 	<arg name="map_file_c" default="willow_garage/willow_garage.yaml"/>
 	<arg name="gmapping_robot_c" default="false"/>
 	<arg name="move_base_robot_c" default="false"/>
@@ -80,7 +88,6 @@
 		<arg name="gazebo_world" value="$(arg gazebo_world)"/>
 		<arg name="gazebo_gui" value="$(arg gazebo_gui)"/>
 		<arg name="omni_drive" value="$(arg omni_drive)"/>
-		<arg name="default_xacro" value="$(arg default_xacro)"/>
 		<arg name="ros_planar_move_plugin" value="$(arg ros_planar_move_plugin)"/>
 		<arg name="ros_planar_move_plugin_force_based" value="$(arg ros_planar_move_plugin_force_based)" />
 		<arg name="launch_advanced_simulation" value="$(arg launch_advanced_simulation)"/>
@@ -89,6 +96,8 @@
 		<arg name="id_robot_a" value="$(arg id_robot_a)"/>
 		<arg name="launch_robot_a" value="$(arg launch_robot_a)"/>
 		<arg name="xacro_robot_a" value="$(arg xacro_robot_a)"/>
+		<arg name="use_custom_xacro_path_robot_a" value="$(arg use_custom_xacro_path_robot_a)"/>
+		<arg name="custom_xacro_path_robot_a" value="$(arg custom_xacro_path_robot_a)"/>
 		<arg name="map_file_a" value="$(arg map_file_a)"/>
 		<arg name="gmapping_robot_a" value="$(arg gmapping_robot_a)"/>
 		<arg name="move_base_robot_a" value="$(arg move_base_robot_a)"/>
@@ -107,6 +116,8 @@
 		<arg name="id_robot_b" value="$(arg id_robot_b)"/>
 		<arg name="launch_robot_b" value="$(arg launch_robot_b)"/>
 		<arg name="xacro_robot_b" value="$(arg xacro_robot_b)"/>
+		<arg name="use_custom_xacro_path_robot_b" value="$(arg use_custom_xacro_path_robot_b)"/>
+		<arg name="custom_xacro_path_robot_b" value="$(arg custom_xacro_path_robot_b)"/>
 		<arg name="gmapping_robot_b" value="$(arg gmapping_robot_b)"/>
 		<arg name="move_base_robot_b" value="$(arg move_base_robot_b)"/>
 		<arg name="ekf_localization_robot_b" value="$(arg ekf_localization_robot_b)"/>
@@ -125,6 +136,8 @@
 		<arg name="id_robot_c" value="$(arg id_robot_c)"/>
 		<arg name="launch_robot_c" value="$(arg launch_robot_c)"/>
 		<arg name="xacro_robot_c" value="$(arg xacro_robot_c)"/>
+		<arg name="use_custom_xacro_path_robot_c" value="$(arg use_custom_xacro_path_robot_c)"/>
+		<arg name="custom_xacro_path_robot_c" value="$(arg custom_xacro_path_robot_c)"/>
 		<arg name="gmapping_robot_c" value="$(arg gmapping_robot_c)"/>
 		<arg name="move_base_robot_c" value="$(arg move_base_robot_c)"/>
 		<arg name="ekf_localization_robot_c" value="$(arg ekf_localization_robot_c)"/>

--- a/summit_xl_sim_bringup/launch/summit_xl_gen_complete.launch
+++ b/summit_xl_sim_bringup/launch/summit_xl_gen_complete.launch
@@ -6,7 +6,9 @@
 	<arg name="launch_rviz" default="true"/>
 	<arg name="gazebo_world" default="$(find summit_xl_gazebo)/worlds/summit_xl_office.world"/>
 	<arg name="omni_drive" default="false"/>
-	<arg name="default_xacro" default="summit_xl_gen_std.urdf.xacro"/>
+	<arg name="default_xacro" default="$(optenv ROBOT_XACRO summit_xl_gen_std.urdf.xacro)"/>
+	<arg name="use_custom_xacro_path" default="$(optenv ROBOT_USE_CUSTOM_XACRO_PATH false)"/>
+	<arg name="custom_xacro_path" default="$(optenv ROBOT_CUSTOM_XACRO_PATH /home/robot/)"/>
 	<arg if="$(arg omni_drive)" name="ros_planar_move_plugin" value="true"/>
 	<arg unless="$(arg omni_drive)" name="ros_planar_move_plugin" default="true"/>
 	<arg name="ros_planar_move_plugin_force_based" default="false"/>
@@ -17,6 +19,8 @@
 	<arg name="id_robot_a" default="robot"/>
 	<arg name="launch_robot_a" default="true"/>
 	<arg name="xacro_robot_a" default="$(arg default_xacro)"/>
+	<arg name="use_custom_xacro_path_robot_a" default="$(arg use_custom_xacro_path)"/>
+	<arg name="custom_xacro_path_robot_a" default="$(arg custom_xacro_path)"/>
 	<arg name="map_file_a" default="willow_garage/willow_garage.yaml"/>
 	<arg name="gmapping_robot_a" default="false"/>
 	<arg name="move_base_robot_a" default="false"/>
@@ -33,6 +37,8 @@
 	<arg name="id_robot_b" default="robot_b"/>
 	<arg name="launch_robot_b" default="false"/>
 	<arg name="xacro_robot_b" default="$(arg default_xacro)"/>
+	<arg name="use_custom_xacro_path_robot_b" default="$(arg use_custom_xacro_path)"/>
+	<arg name="custom_xacro_path_robot_b" default="$(arg custom_xacro_path)"/>
 	<arg name="map_file_b" default="willow_garage/willow_garage.yaml"/>
 	<arg name="gmapping_robot_b" default="false"/>
 	<arg name="move_base_robot_b" default="false"/>
@@ -49,6 +55,8 @@
 	<arg name="id_robot_c" default="robot_c"/>
 	<arg name="launch_robot_c" default="false"/>
 	<arg name="xacro_robot_c" default="$(arg default_xacro)"/>
+	<arg name="use_custom_xacro_path_robot_c" default="$(arg use_custom_xacro_path)"/>
+	<arg name="custom_xacro_path_robot_c" default="$(arg custom_xacro_path)"/>
 	<arg name="map_file_c" default="willow_garage/willow_garage.yaml"/>
 	<arg name="gmapping_robot_c" default="false"/>
 	<arg name="move_base_robot_c" default="false"/>
@@ -75,6 +83,8 @@
 		<arg name="id_robot_a" value="$(arg id_robot_a)"/>
 		<arg name="launch_robot_a" value="$(arg launch_robot_a)"/>
 		<arg name="xacro_robot_a" value="$(arg xacro_robot_a)"/>
+		<arg name="use_custom_xacro_path_robot_a" value="$(arg use_custom_xacro_path_robot_a)"/>
+		<arg name="custom_xacro_path_robot_a" value="$(arg custom_xacro_path_robot_a)"/>
 		<arg name="map_file_a" value="$(arg map_file_a)"/>
 		<arg name="gmapping_robot_a" value="$(arg gmapping_robot_a)"/>
 		<arg name="move_base_robot_a" value="$(arg move_base_robot_a)"/>
@@ -90,6 +100,8 @@
 		<arg name="id_robot_b" value="$(arg id_robot_b)"/>
 		<arg name="launch_robot_b" value="$(arg launch_robot_b)"/>
 		<arg name="xacro_robot_b" value="$(arg xacro_robot_b)"/>
+		<arg name="use_custom_xacro_path_robot_b" value="$(arg use_custom_xacro_path_robot_b)"/>
+		<arg name="custom_xacro_path_robot_b" value="$(arg custom_xacro_path_robot_b)"/>
 		<arg name="gmapping_robot_b" value="$(arg gmapping_robot_b)"/>
 		<arg name="move_base_robot_b" value="$(arg move_base_robot_b)"/>
 		<arg name="amcl_and_mapserver_b" value="$(arg amcl_and_mapserver_b)"/>
@@ -105,6 +117,8 @@
 		<arg name="id_robot_c" value="$(arg id_robot_c)"/>
 		<arg name="launch_robot_c" value="$(arg launch_robot_c)"/>
 		<arg name="xacro_robot_c" value="$(arg xacro_robot_c)"/>
+		<arg name="use_custom_xacro_path_robot_c" value="$(arg use_custom_xacro_path_robot_c)"/>
+		<arg name="custom_xacro_path_robot_c" value="$(arg custom_xacro_path_robot_c)"/>
 		<arg name="gmapping_robot_c" value="$(arg gmapping_robot_c)"/>
 		<arg name="move_base_robot_c" value="$(arg move_base_robot_c)"/>
 		<arg name="amcl_and_mapserver_c" value="$(arg amcl_and_mapserver_c)"/>

--- a/summit_xl_sim_bringup/launch/summit_xls_complete.launch
+++ b/summit_xl_sim_bringup/launch/summit_xls_complete.launch
@@ -16,7 +16,9 @@
 	<arg name="use_gpu_for_simulation" default="$(optenv USE_GPU_FOR_SIMULATION false)"/>
 
 	<!-- common arguments -->
-	<arg name="default_xacro_package" default="$(optenv ROBOT_XACRO_PACKAGE summit_xl_description)"/>
+	<arg name="default_xacro" default="$(optenv ROBOT_XACRO summit_xls_std.urdf.xacro)"/>
+	<arg name="use_custom_xacro_path" default="$(optenv ROBOT_USE_CUSTOM_XACRO_PATH false)"/>
+	<arg name="custom_xacro_path" default="$(optenv ROBOT_CUSTOM_XACRO_PATH /home/robot/)"/>
 
 	<!-- arguments robot a -->
 	<arg name="launch_robot_a" default="true"/>
@@ -24,8 +26,9 @@
 	<arg name="gmapping_robot_a" default="false"/>
 	<arg name="move_base_robot_a" default="true"/>
 	<arg name="amcl_and_mapserver_a" default="true"/>
-	<arg name="xacro_robot_a" default="$(optenv ROBOT_XACRO summit_xls_std.urdf.xacro)"/>
-	<arg name="launch_pad_a" default="false"/>
+	<arg name="xacro_robot_a" default="$(arg default_xacro)"/>
+	<arg name="use_custom_xacro_path_robot_a" default="$(arg use_custom_xacro_path)"/>
+	<arg name="custom_xacro_path_robot_a" default="$(arg custom_xacro_path)"/>	<arg name="launch_pad_a" default="false"/>
 	<arg name="has_pantilt_camera_a" default="false"/>
 
 	<!-- arguments robot b -->
@@ -34,7 +37,9 @@
 	<arg name="gmapping_robot_b" default="false"/>
 	<arg name="move_base_robot_b" default="false"/>
 	<arg name="amcl_and_mapserver_b" default="false"/>
-	<arg name="xacro_robot_b" default="summit_xls_std.urdf.xacro"/>
+	<arg name="xacro_robot_b" default="$(arg default_xacro)"/>
+	<arg name="use_custom_xacro_path_robot_b" default="$(arg use_custom_xacro_path)"/>
+	<arg name="custom_xacro_path_robot_b" default="$(arg custom_xacro_path)"/>
 	<arg name="launch_pad_b" default="false"/>
 	<arg name="has_pantilt_camera_b" default="false"/>
 
@@ -44,7 +49,9 @@
 	<arg name="gmapping_robot_c" default="false"/>
 	<arg name="move_base_robot_c" default="false"/>
 	<arg name="amcl_and_mapserver_c" default="false"/>
-	<arg name="xacro_robot_c" default="summit_xls_std.urdf.xacro"/>
+	<arg name="xacro_robot_c" default="$(arg default_xacro)"/>
+	<arg name="use_custom_xacro_path_robot_c" default="$(arg use_custom_xacro_path)"/>
+	<arg name="custom_xacro_path_robot_c" default="$(arg custom_xacro_path)"/>
 	<arg name="launch_pad_c" default="false"/>
 	<arg name="has_pantilt_camera_c" default="false"/>
 
@@ -57,7 +64,6 @@
 		<arg name="ros_planar_move_plugin_force_based" value="$(arg ros_planar_move_plugin_force_based)" />
 		<arg name="launch_advanced_simulation" value="$(arg launch_advanced_simulation)"/>
 		<arg name="use_gpu_for_simulation" value="$(arg use_gpu_for_simulation)"/>
-		<arg name="default_xacro_package" value="$(arg default_xacro_package)"/>
 		<!-- robot_a args -->
 		<arg name="launch_robot_a" value="$(arg launch_robot_a)"/>
 		<arg name="map_file_a" value="$(arg map_file_a)"/>
@@ -65,6 +71,8 @@
 		<arg name="move_base_robot_a" value="$(arg move_base_robot_a)"/>
 		<arg name="amcl_and_mapserver_a" value="$(arg amcl_and_mapserver_a)"/>
 		<arg name="xacro_robot_a" value="$(arg xacro_robot_a)"/>
+		<arg name="use_custom_xacro_path_robot_a" value="$(arg use_custom_xacro_path_robot_a)"/>
+		<arg name="custom_xacro_path_robot_a" value="$(arg custom_xacro_path_robot_a)"/>
 		<arg name="launch_pad_a" value="$(arg launch_pad_a)"/>
 		<arg name="has_pantilt_camera_a" value="$(arg has_pantilt_camera_a)"/>
 		<!-- robot_b args -->
@@ -74,6 +82,8 @@
 		<arg name="amcl_and_mapserver_b" value="$(arg amcl_and_mapserver_b)"/>
 		<arg name="map_file_b" value="$(arg map_file_b)"/>
 		<arg name="xacro_robot_b" value="$(arg xacro_robot_b)"/>
+		<arg name="use_custom_xacro_path_robot_b" value="$(arg use_custom_xacro_path_robot_b)"/>
+		<arg name="custom_xacro_path_robot_b" value="$(arg custom_xacro_path_robot_b)"/>
 		<arg name="launch_pad_b" value="$(arg launch_pad_b)"/>
 		<arg name="has_pantilt_camera_b" value="$(arg has_pantilt_camera_b)"/>
 
@@ -84,6 +94,8 @@
 		<arg name="amcl_and_mapserver_c" value="$(arg amcl_and_mapserver_c)"/>
 		<arg name="map_file_c" value="$(arg map_file_c)"/>
 		<arg name="xacro_robot_c" value="$(arg xacro_robot_c)"/>
+		<arg name="use_custom_xacro_path_robot_c" value="$(arg use_custom_xacro_path_robot_c)"/>
+		<arg name="custom_xacro_path_robot_c" value="$(arg custom_xacro_path_robot_c)"/>
 		<arg name="launch_pad_c" value="$(arg launch_pad_c)"/>
 		<arg name="has_pantilt_camera_c" value="$(arg has_pantilt_camera_c)"/>
 


### PR DESCRIPTION
This commit allows to use a custom xacro path.

Until now, you can select the xacro package, but it is hardcoded for `/robot/` path. For example, you can
select `robot_bringup` as robot package, but the full path will be `robot_bringup/robots/summit_xl_std.urdf.xacro`

This commit implements the `use_custom_xacro_path` and `custom_xacro_path` parameters. 

When `custom_xacro_path` is set to `False`, the default path is `summit_xl_description/robots/`. If it set to `True` the path
will be `custom_xacro_path`. 

This commit with the default parameters does not affect to the normal behaviour of the simulation.
